### PR TITLE
fix: migrate to zarr v3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "rich",
   "scanpy",
   "xarray",
+  "zarr>=3",
   # for debug logging (referenced from the issue template)
   "session-info",
 ]

--- a/src/cellink/_core/donordata.py
+++ b/src/cellink/_core/donordata.py
@@ -150,8 +150,8 @@ class DonorData:
         for m in [self.G, self.C]:
             if isinstance(m, MuData):
                 raise NotImplementedError("MuData not supported for zarr write")
-        with zarr.open(path, mode="w") as f:
-            self._write_dd(f)
+        f = zarr.open(path, mode="w")
+        self._write_dd(f)
 
     def _ensure_extension(self, path: str, ext: str) -> str:
         """Ensure the given path ends with the desired extension."""

--- a/src/cellink/io/_readwrite.py
+++ b/src/cellink/io/_readwrite.py
@@ -163,8 +163,8 @@ def read_zarr_dd(path: str) -> DonorData:
         A DonorData object with genotype (`G`), cell expression (`C`), and metadata.
     """
         
-    with zarr.open(path, mode="r") as f:
-        return _read_dd(f)
+    f = zarr.open(path, mode="r")
+    return _read_dd(f)
 
 
 def read_dd(path: str, fmt: str = None) -> DonorData:

--- a/src/cellink/io/_sgkit.py
+++ b/src/cellink/io/_sgkit.py
@@ -249,9 +249,14 @@ def from_sgkit_dataset(
 
     if phased_da is not None:
         adata.uns["has_phased_flag"] = True
-        ploidy = inferred_ploidy if inferred_ploidy is not None else phased_da.shape[-1]
-        for h in range(ploidy):
-            adata.layers[f"PHASE_{h}"] = phased_da.data[:, :, h].T
+        phased_data = phased_da.data
+        if phased_data.ndim == 3:
+            ploidy = inferred_ploidy if inferred_ploidy is not None else phased_data.shape[-1]
+            for h in range(ploidy):
+                adata.layers[f"PHASE_{h}"] = phased_data[:, :, h].T
+        else:
+            # 2D (variants, samples) — single phased flag per call
+            adata.layers["PHASE_0"] = phased_data.T
     else:
         adata.uns["has_phased_flag"] = False
 


### PR DESCRIPTION
- Pin zarr>=3 in dependencies
- Replace zarr.open() context manager usage (removed in v3)
- Handle 2D call_genotype_phased array shape in sgkit datasets