### PR TITLE
Subset region

### DIFF
--- a/src/cellink/tl/__init__.py
+++ b/src/cellink/tl/__init__.py
@@ -8,5 +8,5 @@ from ._annotate_snps_genotype_data import (
     run_snpeff,
     run_vep,
 )
-
+from ._subset_region import subset_genomic_region, subset_gene
 from ._rvat import beta_weighting, run_burden_test, run_skat_test

--- a/src/cellink/tl/_subset_region.py
+++ b/src/cellink/tl/_subset_region.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import numpy as np
+
+def subset_genomic_region(gdata, chrom, start, end):
+    """
+    Subset the gdata object to only include variants within the specified genomic region.
+    
+    Parameters:
+    gdata: Anndata object containing the genomic data.
+    chrom: Chromosome name (e.g., 'chr1').
+    start: Start position of the genomic region (0-based).
+    end: End position of the genomic region (0-based).
+    
+    Returns:
+    Subsetted Anndata object containing only variants within the specified genomic region.
+    """
+    # Ensure that the 'chrom', 'pos' columns are present in gdata.var
+    if 'chrom' not in gdata.var.columns or 'pos' not in gdata.var.columns:
+        raise ValueError("gdata.var must contain 'chrom' and 'pos' columns.")
+    # Trying to cast chrom to the same dtype as gdata.var['chrom'] to ensure that subsetting works correctly
+    chrom_column_dtype = type(gdata.var['chrom'].iloc[0])  
+
+    if type(chrom) != chrom_column_dtype:
+        print(f"Attempting to convert chrom value {chrom} from type {type(chrom)} to the same dtype as gdata.var['chrom'] which is {chrom_column_dtype}")
+        try:
+            chrom = chrom_column_dtype(chrom)
+        except Exception as e:  
+            raise ValueError(f"Failed to convert chromosome {chrom} to the expected dtype {chrom_column_dtype}. Error: {e}")
+    # Subset the variants based on the specified genomic region
+    subset_mask = (gdata.var['chrom'] == chrom) & (gdata.var['pos'] >= start) & (gdata.var['pos'] < end)
+    # Check if any variants are found in the specified region
+    if not subset_mask.any():
+        print(f"No variants found in the specified region: {chrom}:{start}-{end}. Returning an empty Anndata object.")
+        return gdata[:, subset_mask].copy()  # Return an empty Anndata object with the same structure
+
+    # Subset the Anndata object
+    subset_gdata = gdata[:, subset_mask].copy()
+    
+    return subset_gdata
+
+def subset_gene(gdata, gene_id: str or list):
+    """
+    Subset the gdata object to only include variants that are annotated to a specific gene.
+    It is required that vep annotations have already been added to gdata and that  'gene_id' is present in gdata.uns["variant_annotation_vep"]
+    Parameters:
+    gdata: Anndata object containing the genomic data.
+    gene_id: Gene identifier (e.g., Ensembl gene ID) to subset by.
+    
+    Returns:
+    Subsetted Anndata object containing only variants annotated to the specified gene.
+    """
+    # Ensure that the 'gene_id' column is present in gdata.var
+    if 'gene_id' not in gdata.uns["variant_annotation_vep"].reset_index().columns:
+        raise ValueError("gdata.uns['variant_annotation_vep'] must contain 'gene_id' column. Have you added VEP annotations to gdata?")
+    
+    # Subset the variants based on the specified gene_id
+    if isinstance(gene_id, list):
+        subset_mask_uns = gdata.uns["variant_annotation_vep"].reset_index()["gene_id"].isin(gene_id)
+    else:
+        subset_mask_uns = gdata.uns["variant_annotation_vep"].reset_index()["gene_id"] == gene_id
+    subset_variants = gdata.uns["variant_annotation_vep"].reset_index()[subset_mask_uns]["snp_id"].unique()
+    subset_mask_var = gdata.var_names.isin(subset_variants)
+    # Subset the Anndata object
+    subset_gdata = gdata[:, subset_mask_var].copy()
+    
+    return subset_gdata

--- a/src/cellink/tl/_subset_region.py
+++ b/src/cellink/tl/_subset_region.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-
+from cellink._core.data_fields import AAnn
 def subset_genomic_region(gdata, chrom, start, end):
     """
     Subset the gdata object to only include variants within the specified genomic region.
@@ -15,10 +15,10 @@ def subset_genomic_region(gdata, chrom, start, end):
     Subsetted Anndata object containing only variants within the specified genomic region.
     """
     # Ensure that the 'chrom', 'pos' columns are present in gdata.var
-    if 'chrom' not in gdata.var.columns or 'pos' not in gdata.var.columns:
+    if AAnn.chrom not in gdata.var.columns or AAnn.pos not in gdata.var.columns:
         raise ValueError("gdata.var must contain 'chrom' and 'pos' columns.")
     # Trying to cast chrom to the same dtype as gdata.var['chrom'] to ensure that subsetting works correctly
-    chrom_column_dtype = type(gdata.var['chrom'].iloc[0])  
+    chrom_column_dtype = type(gdata.var[AAnn.chrom].iloc[0])  
 
     if type(chrom) != chrom_column_dtype:
         print(f"Attempting to convert chrom value {chrom} from type {type(chrom)} to the same dtype as gdata.var['chrom'] which is {chrom_column_dtype}")
@@ -27,7 +27,7 @@ def subset_genomic_region(gdata, chrom, start, end):
         except Exception as e:  
             raise ValueError(f"Failed to convert chromosome {chrom} to the expected dtype {chrom_column_dtype}. Error: {e}")
     # Subset the variants based on the specified genomic region
-    subset_mask = (gdata.var['chrom'] == chrom) & (gdata.var['pos'] >= start) & (gdata.var['pos'] < end)
+    subset_mask = (gdata.var[AAnn.chrom] == chrom) & (gdata.var[AAnn.pos] >= start) & (gdata.var[AAnn.pos] < end)
     # Check if any variants are found in the specified region
     if not subset_mask.any():
         print(f"No variants found in the specified region: {chrom}:{start}-{end}. Returning an empty Anndata object.")

--- a/src/cellink/tl/_subset_region.py
+++ b/src/cellink/tl/_subset_region.py
@@ -49,6 +49,8 @@ def subset_gene(gdata, gene_id: str or list):
     Returns:
     Subsetted Anndata object containing only variants annotated to the specified gene.
     """
+    if "variant_annotation_vep" not in gdata.uns:
+        raise ValueError("VEP annotations must be added to gdata before subsetting by gene. Please run add_vep_annos_to_gdata() first.")
     # Ensure that the 'gene_id' column is present in gdata.var
     if 'gene_id' not in gdata.uns["variant_annotation_vep"].reset_index().columns:
         raise ValueError("gdata.uns['variant_annotation_vep'] must contain 'gene_id' column. Have you added VEP annotations to gdata?")
@@ -62,5 +64,6 @@ def subset_gene(gdata, gene_id: str or list):
     subset_mask_var = gdata.var_names.isin(subset_variants)
     # Subset the Anndata object
     subset_gdata = gdata[:, subset_mask_var].copy()
-    
+    subset_gdata.uns["variant_annotation_vep"] = gdata.uns["variant_annotation_vep"].reset_index().loc[subset_mask_uns].copy()
+    #subset_gdata.uns = gdata.uns[subset_mask_uns].copy()  # Copy uns to preserve annotations
     return subset_gdata

--- a/src/cellink/tl/_subset_region.py
+++ b/src/cellink/tl/_subset_region.py
@@ -38,7 +38,7 @@ def subset_genomic_region(gdata, chrom, start, end):
     
     return subset_gdata
 
-def subset_gene(gdata, gene_id: str or list):
+def subset_gene(gdata, gene_id: str or list, gene_snp_map = "variant_annotation_vep"):
     """
     Subset the gdata object to only include variants that are annotated to a specific gene.
     It is required that vep annotations have already been added to gdata and that  'gene_id' is present in gdata.uns["variant_annotation_vep"]
@@ -49,21 +49,21 @@ def subset_gene(gdata, gene_id: str or list):
     Returns:
     Subsetted Anndata object containing only variants annotated to the specified gene.
     """
-    if "variant_annotation_vep" not in gdata.uns:
+    if gene_snp_map not in gdata.uns:
         raise ValueError("VEP annotations must be added to gdata before subsetting by gene. Please run add_vep_annos_to_gdata() first.")
     # Ensure that the 'gene_id' column is present in gdata.var
-    if 'gene_id' not in gdata.uns["variant_annotation_vep"].reset_index().columns:
-        raise ValueError("gdata.uns['variant_annotation_vep'] must contain 'gene_id' column. Have you added VEP annotations to gdata?")
+    if 'gene_id' not in gdata.uns[gene_snp_map].reset_index().columns:
+        raise ValueError("gdata.uns[gene_snp_map] must contain 'gene_id' column. Have you added VEP annotations to gdata?")
     
     # Subset the variants based on the specified gene_id
     if isinstance(gene_id, list):
-        subset_mask_uns = gdata.uns["variant_annotation_vep"].reset_index()["gene_id"].isin(gene_id)
+        subset_mask_uns = gdata.uns[gene_snp_map].reset_index()["gene_id"].isin(gene_id)
     else:
-        subset_mask_uns = gdata.uns["variant_annotation_vep"].reset_index()["gene_id"] == gene_id
-    subset_variants = gdata.uns["variant_annotation_vep"].reset_index()[subset_mask_uns]["snp_id"].unique()
+        subset_mask_uns = gdata.uns[gene_snp_map].reset_index()["gene_id"] == gene_id
+    subset_variants = gdata.uns[gene_snp_map].reset_index()[subset_mask_uns]["snp_id"].unique()
     subset_mask_var = gdata.var_names.isin(subset_variants)
     # Subset the Anndata object
     subset_gdata = gdata[:, subset_mask_var].copy()
-    subset_gdata.uns["variant_annotation_vep"] = gdata.uns["variant_annotation_vep"].reset_index().loc[subset_mask_uns].copy()
+    subset_gdata.uns[gene_snp_map] = gdata.uns[gene_snp_map].reset_index().loc[subset_mask_uns].copy()
     #subset_gdata.uns = gdata.uns[subset_mask_uns].copy()  # Copy uns to preserve annotations
     return subset_gdata

--- a/tests/test_tl.py
+++ b/tests/test_tl.py
@@ -13,7 +13,10 @@ from cellink.tl import (
     aggregate_annotations_for_varm,
     combine_annotations,
     run_vep,
+    subset_genomic_region,
+    subset_gene,
 )
+
 
 DATA = Path("tests/data")
 CONFIG = Path("configs")
@@ -81,3 +84,22 @@ def test_aggregate_annotations_for_varm(gdata, sample_vep_annos):
         )
         id_cols = [AAnn.index]
         assert len(gdata.uns["variant_annotation_vep"].reset_index()[id_cols].drop_duplicates()) == len(res.index)
+
+def test_get_genomic_region_nosubset(gdata):
+    chrom = gdata.var['chrom'].iloc[0]
+    start = gdata.var['pos'].min()
+    end = gdata.var['pos'].max() + 1
+
+    subset_gdata = subset_genomic_region(gdata, chrom, start, end)
+
+    assert subset_gdata.shape[1] == gdata.shape[1]
+
+
+def test_get_genomic_region_subset(gdata):
+    chrom = gdata.var['chrom'].iloc[0]
+    start = gdata.var['pos'].min() + 1
+    end = gdata.var['pos'].max()
+
+    subset_gdata = subset_genomic_region(gdata, chrom, start, end)
+
+    assert subset_gdata.shape[1] < gdata.shape[1]

--- a/tests/test_tl.py
+++ b/tests/test_tl.py
@@ -103,3 +103,48 @@ def test_get_genomic_region_subset(gdata):
     subset_gdata = subset_genomic_region(gdata, chrom, start, end)
 
     assert subset_gdata.shape[1] < gdata.shape[1]
+
+def test_get_genomic_region_quantile_subset(gdata):
+    chrom = gdata.var['chrom'].iloc[0]
+    start = gdata.var['pos'].quantile(0.25)
+    end = gdata.var['pos'].quantile(0.75)
+
+    subset_gdata = subset_genomic_region(gdata, chrom, start, end)
+    subset_gdata.var['pos'].min() >= start
+    subset_gdata.var['pos'].max() <= end
+    assert subset_gdata.shape[1] < gdata.shape[1]
+
+
+def test_subset_gene_no_vep(gdata):
+   #expect value error if vep annotations have not been added to gdata
+    with pytest.raises(ValueError):
+        subset_gene(gdata, gene_id="ENSG00000141510")
+
+
+def test_subset_non_present_gene(gdata, sample_vep_annos):
+    add_vep_annos_to_gdata(vep_anno_file=sample_vep_annos, gdata=gdata, dummy_consequence=True)
+
+    gene_id = "ENSG00000141510"
+    subset_gdata = subset_gene(gdata, gene_id)
+
+    assert subset_gdata.shape[1] == 0
+
+def test_subset_present_gene(gdata, sample_vep_annos):
+    add_vep_annos_to_gdata(vep_anno_file=sample_vep_annos, gdata=gdata, dummy_consequence=True)
+    gene_id = "ENSG2"
+    subset_gdata = subset_gene(gdata, gene_id)
+    assert subset_gdata.shape[1] < gdata.shape[1]
+    assert subset_gdata.shape[1] > 0
+    assert all(subset_gdata.uns["variant_annotation_vep"].reset_index()[AAnn.gene_id] == gene_id)
+
+
+def test_subset_multiple_genes(gdata, sample_vep_annos):
+    add_vep_annos_to_gdata(vep_anno_file=sample_vep_annos, gdata=gdata, dummy_consequence=True)
+    gene_ids = ["ENSG1","ENSG2", "ENSG3"] # only ENSG1 and ENSG2 are present in the sample vep annos
+    subset_gdata = subset_gene(gdata, gene_ids)
+    assert subset_gdata.shape[1] < gdata.shape[1]
+    assert subset_gdata.shape[1] > 0
+    assert all(subset_gdata.uns["variant_annotation_vep"].reset_index()[AAnn.gene_id].isin(gene_ids))
+    assert "ENSG1" in subset_gdata.uns["variant_annotation_vep"].reset_index()[AAnn.gene_id].values
+    assert "ENSG2" in subset_gdata.uns["variant_annotation_vep"].reset_index()[AAnn.gene_id].values
+    assert "ENSG3" not in subset_gdata.uns["variant_annotation_vep"].reset_index()[AAnn.gene_id].values


### PR DESCRIPTION
Added functionality to subset genomic regions in two ways.
First, by the function `subset_genomic_region`, which takes in  a range of coordinates (chromosome and positions of start and end), and secondly by the function `subset_gene` which takes in one named region (like a gene region) or a list of multipple such regions. `variant_annotation_vep` of the `uns` object is used  for this. Therefore, the object has to be annotated with VEP before subsetting named regions. 


